### PR TITLE
chart: fail to generate image name when using digital tag from develo…

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -75,9 +75,9 @@ return the controller image
 {{- if .Values.image.digest }}
     {{- print "@" .Values.image.digest -}}
 {{- else if .Values.global.imageTagOverride -}}
-    {{- printf ":%s" .Values.global.imageTagOverride -}}
+    {{- printf ":%s" (toString .Values.global.imageTagOverride) -}}
 {{- else if .Values.image.tag -}}
-    {{- printf ":%s" .Values.image.tag -}}
+    {{- printf ":%s" (toString .Values.image.tag) -}}
 {{- else -}}
     {{- printf ":v%s" .Chart.AppVersion -}}
 {{- end -}}
@@ -97,9 +97,9 @@ return the agent image
 {{- if .Values.clusterAgent.agentYaml.image.digest }}
     {{- print "@" .Values.clusterAgent.agentYaml.image.digest -}}
 {{- else if .Values.global.imageTagOverride -}}
-    {{- printf ":%s" .Values.global.imageTagOverride -}}
+    {{- printf ":%s" (toString .Values.global.imageTagOverride) -}}
 {{- else if .Values.clusterAgent.agentYaml.image.tag -}}
-    {{- printf ":%s" .Values.clusterAgent.agentYaml.image.tag -}}
+    {{- printf ":%s" (toString .Values.clusterAgent.agentYaml.image.tag) -}}
 {{- else -}}
     {{- printf ":v%s" .Chart.AppVersion -}}
 {{- end -}}


### PR DESCRIPTION
```
(ai) root@10-20-1-20:/home/welan/bmc# helm template bmc ./chart         --namespace bmc         --create-namespace      --wait  --debug         --set logLevel="debug"    --set image.tag="1263835"       --set clusterAgent.agentYaml.image.tag="1263835"        --set clusterAgent.endpoint.https=false   --set clusterAgent.agentYaml.hostNetwork=false  --set clusterAgent.agentYaml.underlayInterface="spiderpool/eth0-macvlan"        --set clusterAgent.feature.logLevel="debug"       --set clusterAgent.feature.dhcpServerConfig.dhcpServerInterface="net1"  --set clusterAgent.feature.dhcpServerConfig.subnet="192.168.0.0/24"       --set clusterAgent.feature.dhcpServerConfig.ipRange="192.168.0.100-192.168.0.200"       --set clusterAgent.feature.dhcpServerConfig.gateway="192.168.0.1"         --set clusterAgent.feature.dhcpServerConfig.selfIp="192.168.0.2/24"     --set clusterAgent.endpoint.username=""   --set clusterAgent.endpoint.password=""         --set clusterAgent.endpoint.port=8000   --set clusterAgent.storage.type="pvc" | grep image
install.go:214: [debug] Original chart version: ""
install.go:231: [debug] CHART PATH: /home/welan/bmc/chart

            image: {{ .Image }}
          image: ghcr.io/spidernet-io/bmc-controller:%!s(int64=1263835)
          imagePullPolicy: IfNotPresent
    image: "ghcr.io/spidernet-io/bmc-agent:1263835"

```